### PR TITLE
Bump version to 2.0.0-SNAPSHOT for XP 8

### DIFF
--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -13,6 +13,9 @@ jobs:
         with:
           repoUser: ci
           repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          releaseBranch: |
+            master
+            1.x
 
   release:
     runs-on: ubuntu-latest

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,4 +5,4 @@ group = com.enonic.app
 projectName = socialmacros
 appName = com.enonic.app.socialmacros
 xpVersion = 8.0.0-B4
-version=1.4.1-SNAPSHOT
+version=2.0.0-SNAPSHOT


### PR DESCRIPTION
## Summary

- Bumps `version` in `gradle.properties` from `1.4.1-SNAPSHOT` to `2.0.0-SNAPSHOT` so master targets the XP 8 line.
- Adds a `releaseBranch:` block to `.github/workflows/enonic-gradle.yml` listing both `master` and `1.x`, so pushes to either branch are recognized as release-branch builds.
- Companion PR on `1.x` adds the same `releaseBranch:` block so the maintenance branch picks it up too.

## Test plan

- [ ] CI on the PR is green
- [ ] After merge to master, `./gradlew clean build` is green