### PR TITLE
Migrate to lib-asset #46

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,10 +6,12 @@ plugins {
 
 dependencies {
     include xplibs.portal
+    include "com.enonic.lib:lib-asset:2.0.0-SNAPSHOT"
 }
 
 repositories {
     mavenLocal()
     mavenCentral()
     xp.enonicRepo()
+    xp.enonicRepo('dev')
 }

--- a/src/main/resources/cms/macros/youtube/youtube.js
+++ b/src/main/resources/cms/macros/youtube/youtube.js
@@ -1,4 +1,4 @@
-var portal = require('/lib/xp/portal');
+var assetLib = require('/lib/enonic/asset');
 
 exports.macro = function (context) {
     const url = context.params.url;
@@ -20,7 +20,7 @@ exports.macro = function (context) {
         body: html,
         pageContributions: {
             headBegin: [
-                '<link rel="stylesheet" href="' + portal.assetUrl({path: 'css/youtube.css', application: app.name}) + '" type="text/css" />'
+                '<link rel="stylesheet" href="' + assetLib.assetUrl({path: 'css/youtube.css'}) + '" type="text/css" />'
             ]
         }
     }

--- a/src/main/resources/cms/site.yaml
+++ b/src/main/resources/cms/site.yaml
@@ -1,1 +1,3 @@
 kind: "Site"
+apis:
+  - "asset"


### PR DESCRIPTION
Closes #46.

`portal.assetUrl` is `@deprecated` in lib-portal (`Use libAsset or libStatic instead. This function will be removed in future versions.`). The only call in this app is in the YouTube macro, which renders inside a Site, so **lib-asset** is the right target.

## Changes

- `build.gradle` — add `com.enonic.lib:lib-asset:2.0.0-SNAPSHOT` to `include`, and `xp.enonicRepo('dev')` so the SNAPSHOT resolves.
- `src/main/resources/cms/site.yaml` — register `apis: ["asset"]` so the asset API mounts in the Site.
- `src/main/resources/cms/macros/youtube/youtube.js` — `require('/lib/xp/portal')` → `require('/lib/enonic/asset')`; `portal.assetUrl({path, application})` → `assetLib.assetUrl({path})`. The `application` parameter is dropped — lib-asset already resolves against `app.name`.

## Test plan

E2E in `claude-dev` against a `/tmp/xp-e2e-*` XP 8.1.0-SNAPSHOT runtime, with a throwaway bootstrap webapp creating `com.enonic.cms.default` + `default` project + an `e2e` site that has socialmacros applied.

- [x] `./gradlew build --refresh-dependencies` succeeds.
- [x] Bundle reaches ACTIVE in the deployed XP instance: `Started application com.enonic.app.socialmacros bundle 117`.
- [x] `require('/lib/enonic/asset').assetUrl({path: 'css/youtube.css'})` returns a well-formed URL (verified from a sibling webapp).
- [x] The Site-mounted asset endpoint serves the actual CSS:
  ```
  GET /site/default/master/e2e/_/com.enonic.app.socialmacros:asset/x/css/youtube.css
  → HTTP 200, Content-Type: text/css, 270 bytes (correct body)
  ```