### PR TITLE
Introduce TOML version catalog

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 
 dependencies {
     include xplibs.portal
-    include "com.enonic.lib:lib-asset:2.0.0-SNAPSHOT"
+    include libs.lib.asset
 }
 
 repositories {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,5 @@
+[versions]
+asset = "2.0.0-SNAPSHOT"
+
+[libraries]
+lib-asset = { module = "com.enonic.lib:lib-asset", version.ref = "asset" }


### PR DESCRIPTION
## Summary

Move the inline-versioned dependency in `build.gradle` into a new `gradle/libs.versions.toml` catalog. Pin-for-pin migration — no version bumps.

Only one inline-versioned dep existed: `com.enonic.lib:lib-asset:2.0.0-SNAPSHOT`. Everything else was either an `xplibs.*` accessor or untouched.

## Conventions adopted

- Alphabetical sort within `[versions]` and `[libraries]`.
- Hyphen-separated, lowercase keys (`asset`, `lib-asset`).
- `xpVersion` stays in `gradle.properties` — not moved into the catalog.
- `xplibs.*` accessors untouched — they come from the XP gradle plugin.
- No `settings.gradle` change (Gradle auto-discovers `gradle/libs.versions.toml`).

## New catalog

```toml
[versions]
asset = "2.0.0-SNAPSHOT"

[libraries]
lib-asset = { module = "com.enonic.lib:lib-asset", version.ref = "asset" }
```

## Verification

- `./gradlew build --refresh-dependencies` — green.
- `./gradlew dependencies --configuration runtimeClasspath` byte-identical pre/post (only timing line differs).

## Test plan

- [x] Build green locally
- [x] Dependency tree unchanged
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)